### PR TITLE
fix: require ovos-plugin-manager>=2.1.0 for opm.* entry points and cap ovos-* deps at next major

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ classifiers = [
     "Programming Language :: Python :: 3"
 ]
 dependencies = [
-    "ovos-plugin-manager>=0.0.1,<3.0.0",
+    "ovos-plugin-manager>=2.1.0,<3.0.0",
     "ovos-config>=0.0.10",
-    "ovos-utils>=0.4.0"
+    "ovos-utils>=0.4.0,<1.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The `opm.*` entry-point group(s) declared by this package are only recognized by `ovos-plugin-manager>=2.1.0` (canonical in PluginTypes since 2.1.0; `opm.agents.*` since 2.3.0a1). An older plugin-manager queries the legacy entry-point group and silently never discovers the plugin. Also caps all `ovos-*` dependencies at the next major so the latest published versions resolve.