### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,32 @@
 # PHAL plugin - IPGeo
 
-Autoconfigure default location based on ip address via [ip-api.com](https://ip-api.com)
+This plugin sets the default location for OpenVoiceOS based on the IP address of the device. It queries [ip-api.com](https://ip-api.com) and stores the result in the local configuration.
 
-> **This will not overwrite** user defined configuration, only populates values if missing
+The plugin does not overwrite a location that a user or a backend already set. It only fills in the location if the value is missing.
 
-`City`, `regionName` and `country` will be also be localized to your language if possible
+The `City`, `regionName`, and `country` fields are localized to the active language when possible. Supported languages are `en`, `de`, `es`, `pt`, `fr`, `ja`, `zh`, and `ru`.
 
-Supported langs: `"en", "de", "es", "pt", "fr", "ja", "zh", "ru"`
+## Install
+
+```bash
+pip install ovos-phal-plugin-ipgeo
+```
+
+## Usage
+
+OVOS loads this plugin through the PHAL plugin manager. No manual setup is required.
+
+The plugin geolocates the device on these bus messages:
+
+- `mycroft.internet.connected`: sent when the device gets an internet connection.
+- `ovos.ipgeo.update`: sent to request a location update. Send `overwrite: true` in the message data to replace an existing location.
+
+## Related projects
+
+- [OpenVoiceOS/PHAL](https://github.com/OpenVoiceOS/PHAL): the plugin host that loads this plugin.
+- [OpenVoiceOS/ovos-PHAL-plugin-gpsd](https://github.com/OpenVoiceOS/ovos-PHAL-plugin-gpsd): sets the device location from a GPS receiver.
+- [OpenVoiceOS/ovos-PHAL-plugin-connectivity-events](https://github.com/OpenVoiceOS/ovos-PHAL-plugin-connectivity-events): reports network connectivity changes on the bus.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Rewrites the README in Simplified Technical English for clarity: expands the description, adds install and usage sections, documents the bus messages the plugin listens for, and links related PHAL plugins in the org.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation instructions and clarified plugin loading behavior.
  * Documented bus messages and overwrite semantics.
  * Improved explanations of IP geolocation and localization.
  * Added related projects and licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->